### PR TITLE
Modify installation target to /usr/local prefix to allow El capitain …

### DIFF
--- a/rainbow
+++ b/rainbow
@@ -33,7 +33,7 @@ The script version number.
 @type: string
 """
 
-RAINBOW_CONFIGS_HOME = os.path.join(os.sep,'usr','share','rainbow','configs')
+RAINBOW_CONFIGS_HOME = os.path.join(os.sep,'usr','local','share','rainbow','configs')
 """
 The location where rainbow configs are stored.
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setup(
     ],
     scripts=['rainbow'],
     data_files=[
-      ('/usr/share/rainbow/configs', glob.glob('configs/*')),
-      ('/etc/bash_completion.d', ['completion/bash/rainbow']),
-      ('/usr/share/zsh/site-functions', ['completion/zsh/_rainbow'])
+      ('/usr/local/share/rainbow/configs', glob.glob('configs/*')),
+      ('/usr/local/etc/bash_completion.d', ['completion/bash/rainbow']),
+      ('/usr/local/share/zsh/site-functions', ['completion/zsh/_rainbow'])
     ]
 )


### PR DESCRIPTION
…installs.

El Capitain prevents even sudo access to /usr/*, so
/usr/local is a prefereble target location.
