### PR TITLE
Add tcpdump.cfg

### DIFF
--- a/rainbow/config/builtin/tcpdump.cfg
+++ b/rainbow/config/builtin/tcpdump.cfg
@@ -14,7 +14,7 @@ yellow: ([0-9a-f]{2}\:){5}[0-9a-f]{2}
 # 3.  UDP indicator with checksum indicator
 #         Note: Bare "[udp sum ok]" is highlighted because tcpdump will
 #         sometimes omit the "UDP"
-cyan: (?<=Flags )\[[SP\.F]+\]
+cyan: (?<=Flags )\[[SP\.RFU]+\]
       (?<=\: )UDP
       (?<=\: )\[udp sum ok\]( UDP)?
 

--- a/rainbow/config/builtin/tcpdump.cfg
+++ b/rainbow/config/builtin/tcpdump.cfg
@@ -1,0 +1,36 @@
+[filters]
+# IPv4 address+port:
+reset-all-after: (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,5}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
+magenta-before: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
+blue-after: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\.
+reset-after: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
+
+# MAC address:
+yellow: ([0-9a-f]{2}\:){5}[0-9a-f]{2}
+
+# TCP/UDP flags:
+# 1.  TCP Flags
+# 2.  UDP indicator
+# 3.  UDP indicator with checksum indicator
+#         Note: Bare "[udp sum ok]" is highlighted because tcpdump will
+#         sometimes omit the "UDP"
+cyan: (?<=Flags )\[[SP\.F]+\]
+      (?<=\: )UDP
+      (?<=\: )\[udp sum ok\]( UDP)?
+
+# error conditions (UDP, TCP, IPv4):
+red: (?<=\: )\[bad udp cksum.*?\]
+     cksum \S+ \(incorrect.*?\)
+     bad cksum .*?!
+
+# Network-layer Description (e.g. "IP")
+# 1.  With -e flag
+# 2.  With -e flag where no link layer addresses exist (e.g. VPN interface)
+# 3.  Without -e flag
+bold: (?<=ethertype )\S+ \S+(?=,)
+      (?<=^\d{2}\:\d{2}\:\d{2}\.\d{6} AF )[^\s\:]+\s
+      (?<=^\d{2}\:\d{2}\:\d{2}\.\d{6} )[^\s\:]+\s
+
+# Time stamp:
+faint: \d{2}\:\d{2}\:\d{2}\.\d{6}
+


### PR DESCRIPTION
Add a tcpdump.cfg to builtin configs. Tested with various permutations of -v, -e, -n, -S, -X.

Color design notes:
1. The IP and Ethernet address colors are based on `ip address --color`. It also matches the IP color in `ping.cfg`.
2. I didn't find any precedent for port number color, though blue seemed to go nicely with the magenta.
3. The `faint` timestamp feels like a nice balance to me. It sort of highlights the start of the packet (helpful for multi-line packets) without drawing too much visual attention to itself. I tried bold but that seemed to add visual clutter.

Known limitations:
1. Only the default timestamp format is supported.
2. Transport layer protocols besides TCP and UDP not supported.
3. Network layer protocols besides IPv4 and IPv6 not tested.
4. Ditto for unusual link-layer protocols.

As an aside: More expressive filters could help this config; there are a few hacks to make it work right now. If one could configure overlapping patterns, that would help a lot. A major trouble is that after colors are added, the same expression cannot be used in a lookbehind -- apparently because the ANSI color codes are now inserted into the string.