### PR TITLE
Add support for all common cryptographic hashes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,12 +137,6 @@ If you want to request and/or plan to working on one, please send a pull request
 | screen               | :x:                  | cope                                     |                                      |
 | sdiff                | :x:                  | cwrapper                                 |                                      |
 | services             | :x:                  | cwrapper                                 |                                      |
-| sha1sum              | :x:                  | cope                                     | rainbow config needed                |
-| sha224sum            | :x:                  | cope                                     | rainbow config needed                |
-| sha256sum            | :x:                  | cope                                     | rainbow config needed                |
-| sha384sum            | :x:                  | cope                                     | rainbow config needed                |
-| sha512sum            | :x:                  | cope                                     | rainbow config needed                |
-| shasum               | :x:                  | cope                                     | rainbow config needed                |
 | showmount            | :x:                  | cwrapper                                 |                                      |
 | smbstatus            | :x:                  | cwrapper                                 |                                      |
 | socklist             | :x:                  | cope                                     |                                      |

--- a/rainbow/config/builtin/b2sum.cfg
+++ b/rainbow/config/builtin/b2sum.cfg
@@ -1,0 +1,1 @@
+md5sum.cfg

--- a/rainbow/config/builtin/md5sum.cfg
+++ b/rainbow/config/builtin/md5sum.cfg
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # rainbow, a terminal colorizer - https://github.com/nicoulaj/rainbow
-# copyright (c) 2010-2018 rainbow contributors
+# copyright (c) 2010-2022 rainbow contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,4 +23,7 @@
 # ----------------------------------------------------------------------
 
 [filters]
-faint: ^([^\ ]+)
+faint: ^([0-9a-f]+)\s
+green: (?<=\: )OK$
+red: (?<=\: )FAILED$|\s+FAILED\s+
+yellow: \s+WARNING

--- a/rainbow/config/builtin/sha1sum.cfg
+++ b/rainbow/config/builtin/sha1sum.cfg
@@ -1,0 +1,1 @@
+md5sum.cfg

--- a/rainbow/config/builtin/sha224sum.cfg
+++ b/rainbow/config/builtin/sha224sum.cfg
@@ -1,0 +1,1 @@
+md5sum.cfg

--- a/rainbow/config/builtin/sha256sum.cfg
+++ b/rainbow/config/builtin/sha256sum.cfg
@@ -1,0 +1,1 @@
+md5sum.cfg

--- a/rainbow/config/builtin/sha384sum.cfg
+++ b/rainbow/config/builtin/sha384sum.cfg
@@ -1,0 +1,1 @@
+md5sum.cfg

--- a/rainbow/config/builtin/sha3sum.cfg
+++ b/rainbow/config/builtin/sha3sum.cfg
@@ -1,0 +1,1 @@
+md5sum.cfg

--- a/rainbow/config/builtin/sha512sum.cfg
+++ b/rainbow/config/builtin/sha512sum.cfg
@@ -1,0 +1,1 @@
+md5sum.cfg


### PR DESCRIPTION
Reuses `md5sum.cfg` for other commands with the same UI via symlinks.
Adds support for the `-c` option.