### PR TITLE
Update java-stack-trace.cfg for "common frames omitted"

### DIFF
--- a/rainbow/config/builtin/java-stack-trace.cfg
+++ b/rainbow/config/builtin/java-stack-trace.cfg
@@ -20,4 +20,4 @@
 # ----------------------------------------------------------------------
 
 [filters]
-red: ^[a-zA-Z\.]*Exception.*|^\s+at\s.*|^Caused\ by:.*|^\s+\.\.\.\ [0-9]+\smore
+red: ^[a-zA-Z\.]*Exception.*|^\s+at\s.*|^Caused\ by:.*|^\s+\.\.\.\ [0-9]+\smore|^\s+\.\.\.\s[0-9]+\scommon frames omitted

--- a/rainbow/config/builtin/java-stack-trace.cfg
+++ b/rainbow/config/builtin/java-stack-trace.cfg
@@ -20,4 +20,4 @@
 # ----------------------------------------------------------------------
 
 [filters]
-red: ^[a-zA-Z\.]*Exception.*|^\s+at\s.*|^Caused\ by:.*|^\s+\.\.\.\ [0-9]+\smore|^\s+\.\.\.\s[0-9]+\scommon frames omitted
+red: ^[a-zA-Z\.]*Exception.*|^\s+at\s.*|^Caused\ by:.*|^\s+\.\.\.\ [0-9]+\s(more|common frames omitted)


### PR DESCRIPTION
Color `... n common frames omitted` rows that are sometimes part of stack traces as red too.