### PR TITLE
add config for ctest

### DIFF
--- a/rainbow/config/builtin/ctest.cfg
+++ b/rainbow/config/builtin/ctest.cfg
@@ -1,0 +1,27 @@
+# ----------------------------------------------------------------------
+# rainbow, a terminal colorizer - https://github.com/nicoulaj/rainbow
+# copyright (c) 2010-2018 rainbow contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------
+# Description:
+#   Example Rainbow configuration for the 'ctest' command.
+#
+# Usage:
+#   $ rainbow ctest --verbose [options]
+# ----------------------------------------------------------------------
+
+[filters]
+green: PASS(?=\s+:.*)
+red: FAIL!(?=\s+:.*)


### PR DESCRIPTION
Add a simple config for `ctest`.
![ctest-cfg](https://user-images.githubusercontent.com/13196860/213949077-40b0540e-4dfc-4255-84d2-f8b564ab2827.png)

I wanted to make the matching more precise by prepending a positive lookbehind `(?<=^\d+:\s+)`, but got an error that this only works for fixed width patterns. I don't quite understand what to make of this message; is the problem the `+`? Is there some other way to refine the regex like this?